### PR TITLE
Обновление используемой версии gulp-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-pug": "^3.0.3",
     "gulp-rename": "^1.2.2",
     "gulp-rigger": "*",
-    "gulp-sass": "^2.1.1",
+    "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "*",
     "gulp-svgmin": "^1.2.2",
     "gulp-svgstore": "^5.0.5",


### PR DESCRIPTION
Исправляет ошибку при установке с node 8